### PR TITLE
Always show user IDs regardless of count

### DIFF
--- a/lib/rollout/ui/views/features/show.slim
+++ b/lib/rollout/ui/views/features/show.slim
@@ -44,19 +44,14 @@ form.p-6.bg-gray-100.max-w-lg.w-full.text-sm.rounded-sm action=feature_path(@fea
 
   .mb-5
     label.block.text-gray-500.mb-2 Users
-
-    - if @feature.users.count > 100
-      .appearance-none.border.rounded-sm.w-full.py-2.px-4.text-gray-600.leading-relaxed.bg-gray-100
-        = @feature.users.count
-    - else
-      textarea.appearance-none.border.rounded-sm.w-full.py-2.px-4.text-gray-600.leading-relaxed.bg-white(
-        name='users'
-        id='users'
-        value=@feature.users.join(', ')
-        class='hover:border-gray-500'
-        rows='2'
-      )
-        = @feature.users.join(', ')
+    textarea.appearance-none.border.rounded-sm.w-full.py-2.px-4.text-gray-600.leading-relaxed.bg-white(
+      name='users'
+      id='users'
+      value=@feature.users.join(', ')
+      class='hover:border-gray-500'
+      rows='2'
+    )
+      = @feature.users.join(', ')
 
   .flex.items-center.justify-end
     form action=delete_feature_path(@feature.name) method='POST'


### PR DESCRIPTION
**Forked Rollout-ui gem**

PR removes the limit of 100 when showing user IDs for each feature